### PR TITLE
Added attr.ib(init=False) to satisfy static analysis

### DIFF
--- a/sparepo/read.py
+++ b/sparepo/read.py
@@ -64,19 +64,19 @@ class SpatialLoader:
     hashtable: Path = attr.ib(converter=Path)
     snapshot: Path = attr.ib(converter=Path)
 
-    box_size: float
-    number_of_chunks: int
-    unit: str
-    hubble_param: float
-    hubble_param_scaling: int
-    scale_factor: float
+    box_size: float = attr.ib(init=False)
+    number_of_chunks: int = attr.ib(init=False)
+    unit: str = attr.ib(init=False)
+    hubble_param: float = attr.ib(init=False)
+    hubble_param_scaling: int = attr.ib(init=False)
+    scale_factor: float = attr.ib(init=False)
 
-    available_part_types: List[ParticleType]
-    centers: np.ndarray
-    counts: Dict[ParticleType, np.ndarray]
-    cell_size: float
-    number_of_cells: int
-    cells_per_axis: int
+    available_part_types: List[ParticleType] = attr.ib(init=False)
+    centers: np.ndarray = attr.ib(init=False)
+    counts: Dict[ParticleType, np.ndarray] = attr.ib(init=False)
+    cell_size: float = attr.ib(init=False)
+    number_of_cells: int = attr.ib(init=False)
+    cells_per_axis: int = attr.ib(init=False)
 
     def __attrs_post_init__(self):
         """

--- a/sparepo/regions.py
+++ b/sparepo/regions.py
@@ -16,7 +16,6 @@ import attr
 import h5py
 import numpy as np
 
-from sparepo.accelerated import ranges_from_array
 from sparepo.particle_types import ParticleType
 
 
@@ -35,13 +34,13 @@ class SpatialRegion:
     instance for performance reasons.
     """
 
-    cell_mask: np.ndarray
-    cells_to_use: np.ndarray
+    cell_mask: np.ndarray = attr.ib(init=False)
+    cells_to_use: np.ndarray = attr.ib(init=False)
 
-    file_mask: Dict[ParticleType, Dict[int, np.ndarray]]
-    file_counts: Dict[ParticleType, Dict[int, int]]
+    file_mask: Dict[ParticleType, Dict[int, np.ndarray]] = attr.ib(init=False)
+    file_counts: Dict[ParticleType, Dict[int, int]] = attr.ib(init=False)
 
-    mask_calculated: bool
+    mask_calculated: bool = attr.ib(init=False)
 
     def __attrs_post_init__(self):
         self.file_mask = {}
@@ -148,10 +147,10 @@ class CartesianSpatialRegion(SpatialRegion):
     y: Tuple[float] = attr.ib()
     z: Tuple[float] = attr.ib()
 
-    mask_calculated = False
+    mask_calculated: bool = attr.ib(init=False)
 
-    cell_mask: np.ndarray
-    cells_to_use: np.ndarray
+    cell_mask: np.ndarray = attr.ib(init=False)
+    cells_to_use: np.ndarray = attr.ib(init=False)
 
     def set_cell_mask(self, centers: np.ndarray, cell_size: float):
         """
@@ -228,10 +227,10 @@ class SphericalSpatialRegion(SpatialRegion):
     center: Tuple[float] = attr.ib()
     radius: float = attr.ib(converter=float)
 
-    mask_calculated = False
+    mask_calculated: bool = attr.ib(init=False)
 
-    cell_mask: np.ndarray
-    cells_to_use: np.ndarray
+    cell_mask: np.ndarray = attr.ib(init=False)
+    cells_to_use: np.ndarray = attr.ib(init=False)
 
     def set_cell_mask(self, centers: np.ndarray, cell_size: float):
         """


### PR DESCRIPTION
Fixes some static analysis issues where the LSP thinks that we have far more initialisation attributes than we really have.